### PR TITLE
Better way to handle incoming connection

### DIFF
--- a/cmd/src/naivedb-server.rs
+++ b/cmd/src/naivedb-server.rs
@@ -49,6 +49,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     let s = Server::new(address.to_string(), config).await;
-    let _ = s.start().await;
+
+    if let Err(err) = s.start().await {
+        panic!("Server error: {}", err);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

A new connection should be spawned to the runtime to prevent blocking other connections.

Also, I refined the error handling in my taste ;)

@Little-Wallace PTAL